### PR TITLE
Fix typo in function calling schema (Engligh  -> English)

### DIFF
--- a/app/backend/ragtools.py
+++ b/app/backend/ragtools.py
@@ -8,7 +8,7 @@ from rtmt import RTMiddleTier, Tool, ToolResult, ToolResultDirection
 _search_tool_schema = {
     "type": "function",
     "name": "search",
-    "description": "Search the knowledge base. The knowledge base is in English, translate to and from Engligh if " + \
+    "description": "Search the knowledge base. The knowledge base is in English, translate to and from English if " + \
                    "needed. Results are formatted as a source name first in square brackets, followed by the text " + \
                    "content, and a line with '-----' at the end of each result.",
     "parameters": {


### PR DESCRIPTION
This pull request includes a small change to the `app/backend/ragtools.py` file. The change corrects a typo in the description of the `_search_tool_schema`.

* [`app/backend/ragtools.py`](diffhunk://#diff-8252d3ca52991b77563fd67ca3ac7c42e1cdffbeb287b4470bc43d2d2d407f00L11-R11): Corrected the typo "Engligh" to "English" in the `_search_tool_schema` description.

By the way, great boilerplate project! Looking forward to dive deeper into this! 🚀