### PR TITLE
wss path to Azure OpenAI corrected

### DIFF
--- a/app/backend/rtmt.py
+++ b/app/backend/rtmt.py
@@ -167,7 +167,7 @@ class RTMiddleTier:
 
     async def _forward_messages(self, ws: web.WebSocketResponse):
         async with aiohttp.ClientSession(base_url=self.endpoint) as session:
-            params = { "api-version": "alpha" }
+            params = { "api-version": "2024-10-01-preview", "deployment": "gpt-4o-realtime-preview" } #
             headers = {}
             if "x-ms-client-request-id" in ws.headers:
                 headers["x-ms-client-request-id"] = ws.headers["x-ms-client-request-id"]
@@ -175,7 +175,7 @@ class RTMiddleTier:
                 headers = { "api-key": self.key }
             else:
                 headers = { "Authorization": f"Bearer {self._token_provider()}" } # NOTE: no async version of token provider, maybe refresh token on a timer?
-            async with session.ws_connect("/realtime", headers=headers, params=params) as target_ws:
+            async with session.ws_connect("/openai/realtime", headers=headers, params=params) as target_ws:
                 async def from_client_to_server():
                     async for msg in ws:
                         if msg.type == aiohttp.WSMsgType.TEXT:

--- a/app/backend/rtmt.py
+++ b/app/backend/rtmt.py
@@ -167,7 +167,7 @@ class RTMiddleTier:
 
     async def _forward_messages(self, ws: web.WebSocketResponse):
         async with aiohttp.ClientSession(base_url=self.endpoint) as session:
-            params = { "api-version": "2024-10-01-preview", "deployment": "gpt-4o-realtime-preview" } #
+            params = { "api-version": "2024-10-01-preview", "deployment": "gpt-4o-realtime-preview" }
             headers = {}
             if "x-ms-client-request-id" in ws.headers:
                 headers["x-ms-client-request-id"] = ws.headers["x-ms-client-request-id"]


### PR DESCRIPTION
I believe the way how the url is constructed seems to be incorrect.
The "api-version" is currently set to "alpha", which didn't work and led to 404 error.
I have the audio GPT-4o model deployed in swedencentral. 

I adjusted the constructed url to match with what is described in the Azure Sample repo:
https://github.com/azure-samples/aoai-realtime-audio-sdk
However, the sample repo seems also to have a slight error right now as the deployment needs to be "gpt-4o-realtime-preview" without the 1001 at the end.

So the url that i got to work is:
wss://my-eastus2-openai-resource.openai.azure.com/openai/realtime?api-version=2024-10-01-preview&deployment=gpt-4o-realtime-preview

For the future, it makes sense to load the variables from .env file.

