### PR TITLE
Improve devcontainer and update to Python 3.12, add Azure CLI, postCr…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
     "name": "Azure AI Search VoiceRAG",
-    "image": "mcr.microsoft.com/devcontainers/python:3.11",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
+        "ghcr.io/devcontainers/features/azure-cli:1": {},
         "ghcr.io/devcontainers/features/node:1": {
             "version": "20"
         }
     },
+
+    // Configure tool-specific properties.
     "customizations": {
         "vscode": {
             "extensions": [
                 "esbenp.prettier-vscode",
-                "bradlc.vscode-tailwindcss"
+                "bradlc.vscode-tailwindcss",
+                "GitHub.copilot-chat"
             ]
         }
     },
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
     "forwardPorts": [8765],
-    "remoteUser": "vscode"
-  }
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "cd app/frontend && npm install && cd ../backend && pip install -r requirements.txt"
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
     "name": "Azure AI Search VoiceRAG",
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
-
+    "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
         "ghcr.io/devcontainers/features/azure-cli:1": {},
@@ -11,7 +10,6 @@
             "version": "20"
         }
     },
-
     // Configure tool-specific properties.
     "customizations": {
         "vscode": {
@@ -22,13 +20,12 @@
             ]
         }
     },
-
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    "forwardPorts": [8765],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "cd app/frontend && npm install && cd ../backend && pip install -r requirements.txt"
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+    "forwardPorts": [
+        8765
+    ],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "cd app/frontend && npm install && cd ../backend && pip install -r requirements.txt"
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
     "name": "Azure AI Search VoiceRAG",
-    "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
         "ghcr.io/devcontainers/features/azure-cli:1": {},
@@ -26,6 +26,4 @@
     ],
     // Use 'postCreateCommand' to run commands after the container is created.
     "postCreateCommand": "cd app/frontend && npm install && cd ../backend && pip install -r requirements.txt"
-    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-    // "remoteUser": "root"
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly


### PR DESCRIPTION
@chuwik did create my devcontainer already, and just saw your recent update! Decided to add my changes to your devcontainer. Let me know if the changes make any sense and if you are open for contributoin, or if you would like any of the changes reverted.

- Added default comments to devcontainer to make it easier for first time users
- Bump devcontainer to use Python 3.12 (as supported by the project)
- Added Copilot (Chat) as default extension
- Added Azure CLI (required for auth via Azure Identity support instead of key based access)
- Added postCreateCommand to install the dependencies on container creation
- Remove vscode user, which is not required with these default devcontainer images
- Add devcontainer to dependabot updates