### PR TITLE
Avoid return before hook

### DIFF
--- a/app/frontend/src/components/ui/grounding-files.tsx
+++ b/app/frontend/src/components/ui/grounding-files.tsx
@@ -30,11 +30,11 @@ const variants: Variants = {
 
 export function GroundingFiles({ files, onSelected }: Properties) {
     const { t } = useTranslation();
+    const isAnimating = useRef(false);
+
     if (files.length === 0) {
         return null;
     }
-
-    const isAnimating = useRef(false);
 
     return (
         <Card className="m-4 max-w-full md:max-w-md lg:min-w-96 lg:max-w-2xl">

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -14,5 +14,13 @@ export default defineConfig({
         alias: {
             "@": path.resolve(__dirname, "./src")
         }
+    },
+    server: {
+        proxy: {
+            "/realtime": {
+                target: "ws://localhost:8765",
+                ws: true
+            }
+        }
     }
 });

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -14,13 +14,5 @@ export default defineConfig({
         alias: {
             "@": path.resolve(__dirname, "./src")
         }
-    },
-    server: {
-        proxy: {
-            "/realtime": {
-                target: "ws://localhost:8765",
-                ws: true
-            }
-        }
     }
 });


### PR DESCRIPTION
I was getting a React error locally, and GitHub Copilot suggested that you need to always declare your hook at top of component, no after an early return. The fix seemed to work.