### PR TITLE
Fix: Graceful closure of target WebSocket after client disconnects

### DIFF
--- a/app/backend/rtmt.py
+++ b/app/backend/rtmt.py
@@ -187,6 +187,11 @@ class RTMiddleTier:
                         else:
                             print("Error: unexpected message type:", msg.type)
 
+                # Means it is gracefully closed by the client then time to close the target_ws
+                if target_ws:
+                    print("Closing OpenAI's realtime socket connection.")
+                    await target_ws.close()
+                        
                 async def from_server_to_client():
                     async for msg in target_ws:
                         if msg.type == aiohttp.WSMsgType.TEXT:

--- a/app/backend/rtmt.py
+++ b/app/backend/rtmt.py
@@ -186,11 +186,11 @@ class RTMiddleTier:
                                 await target_ws.send_str(new_msg)
                         else:
                             print("Error: unexpected message type:", msg.type)
-
-                # Means it is gracefully closed by the client then time to close the target_ws
-                if target_ws:
-                    print("Closing OpenAI's realtime socket connection.")
-                    await target_ws.close()
+                    
+                    # Means it is gracefully closed by the client then time to close the target_ws
+                    if target_ws:
+                        print("Closing OpenAI's realtime socket connection.")
+                        await target_ws.close()
                         
                 async def from_server_to_client():
                     async for msg in target_ws:


### PR DESCRIPTION
**Description:**

This PR addresses an issue where the server-to-server WebSocket connection (`target_ws`) was not being gracefully closed when the client-side WebSocket (ws) was disconnected, such as when a user closes the browser or the app.

**Key Changes:**

Added logic to close the `target_ws` WebSocket connection after the client disconnects, ensuring proper resource cleanup, especially given the limitations of OpenAI’s real-time connections, and preventing potential resource leaks

**Testing:**

- Verified that WebSocket connections close gracefully without hanging or leaving open connections when the client disconnects.
- Tested in scenarios where the client closes the connection (e.g., closing the browser) and confirmed that the target_ws is closed as expected.