### PR TITLE
Add OpenAiServiceLocation as an azd env variable

### DIFF
--- a/.github/workflows/template-validation.yaml
+++ b/.github/workflows/template-validation.yaml
@@ -23,6 +23,7 @@ jobs:
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
           AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
           AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
+          AZURE_OPENAI_SERVICE_LOCATION: ${{ vars.AZURE_OPENAI_SERVICE_LOCATION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: print result

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -85,7 +85,7 @@ param openAiRealtimeVoiceChoice string = ''
     type: 'location'
   }
 })
-param openAiResourceLocation string
+param openAiServiceLocation string
 
 param realtimeDeploymentCapacity int
 param embeddingDeploymentCapacity int
@@ -253,7 +253,7 @@ module openAi 'br/public:avm/res/cognitive-services/account:0.8.0' = if (!reuseE
   scope: openAiResourceGroup
   params: {
     name: !empty(openAiServiceName) ? openAiServiceName : '${abbrs.cognitiveServicesAccounts}${resourceToken}'
-    location: openAiResourceLocation
+    location: openAiServiceLocation
     tags: tags
     kind: 'OpenAI'
     customSubDomainName: !empty(openAiServiceName)

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -14,6 +14,9 @@
     "principalId": {
       "value": "${AZURE_PRINCIPAL_ID}"
     },
+    "openAiServiceLocation": {
+      "value": "${AZURE_OPENAI_SERVICE_LOCATION}"
+    },
     "openAiServiceName": {
       "value": "${AZURE_OPENAI_SERVICE}"
     },


### PR DESCRIPTION
This allows the location to be set via "azd env set" and in the template validation pipeline, also updated. This approach is what's recommended by the template validation team.

I tested that a brand new environment will still prompt for a location if none has been set.