### PR TITLE
Add support for symlinks to files

### DIFF
--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
         sourcemap: true
     },
     resolve: {
+        preserveSymlinks: true,
         alias: {
             "@": path.resolve(__dirname, "./src")
         }


### PR DESCRIPTION
Without symlink support I get the following error because my repo drive uses a symlink.

```
x Build failed in 2.87s
error during build:
[vite:build-html] The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths, received "D:/git/azure_agent/evals/a11y_summit/audio_1/app/frontend/index.html".
    at getRollupError (file:///d:/git/azure_agent/evals/a11y_summit/audio_1/app/frontend/node_modules/rollup/dist/es/shared/parseAst.js:392:41)
    at error (file:///d:/git/azure_agent/evals/a11y_summit/audio_1/app/frontend/node_modules/rollup/dist/es/shared/parseAst.js:388:42)
    at FileEmitter.emitFile (file:///d:/git/azure_agent/evals/a11y_summit/audio_1/app/frontend/node_modules/rollup/dist/es/shared/node-entry.js:19433:24)
    at Object.generateBundle (file:///d:/git/azure_agent/evals/a11y_summit/audio_1/app/frontend/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:35616:14)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Bundle.generate (file:///d:/git/azure_agent/evals/a11y_summit/audio_1/app/frontend/node_modules/rollup/dist/es/shared/node-entry.js:18310:9)
    at async file:///d:/git/azure_agent/evals/a11y_summit/audio_1/app/frontend/node_modules/rollup/dist/es/shared/node-entry.js:20853:27
    at async catchUnfinishedHookActions (file:///d:/git/azure_agent/evals/a11y_summit/audio_1/app/frontend/node_modules/rollup/dist/es/shared/node-entry.js:20282:16)
    at async build (file:///d:/git/azure_agent/evals/a11y_summit/audio_1/app/frontend/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:65392:16)
    at async CAC.<anonymous> (file:///d:/git/azure_agent/evals/a11y_summit/audio_1/app/frontend/node_modules/vite/dist/node/cli.js:828:5)
Failed to build frontend
```