### PR TITLE
Update dependabot.yml with GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,16 @@
 
 version: 2
 updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
  - package-ecosystem: "devcontainers"
    directory: "/"
    schedule:


### PR DESCRIPTION
This is my preferred way to address https://github.com/Azure-Samples/aisearch-openai-rag-audio/issues/65

Once merged, dependabot will send an update for the outdated GitHub actions versions.
