### PR TITLE
Modify system message to multi-line string notation

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -40,13 +40,16 @@ async def create_app():
         deployment=os.environ["AZURE_OPENAI_REALTIME_DEPLOYMENT"],
         voice_choice=os.environ.get("AZURE_OPENAI_REALTIME_VOICE_CHOICE") or "alloy"
         )
-    rtmt.system_message = "You are a helpful assistant. Only answer questions based on information you searched in the knowledge base, accessible with the 'search' tool. " + \
-                          "The user is listening to answers with audio, so it's *super* important that answers are as short as possible, a single sentence if at all possible. " + \
-                          "Never read file names or source names or keys out loud. " + \
-                          "Always use the following step-by-step instructions to respond: \n" + \
-                          "1. Always use the 'search' tool to check the knowledge base before answering a question. \n" + \
-                          "2. Always use the 'report_grounding' tool to report the source of information from the knowledge base. \n" + \
-                          "3. Produce an answer that's as short as possible. If the answer isn't in the knowledge base, say you don't know."
+    rtmt.system_message = """
+        You are a helpful assistant. Only answer questions based on information you searched in the knowledge base, accessible with the 'search' tool. 
+        The user is listening to answers with audio, so it's *super* important that answers are as short as possible, a single sentence if at all possible. 
+        Never read file names or source names or keys out loud. 
+        Always use the following step-by-step instructions to respond: 
+        1. Always use the 'search' tool to check the knowledge base before answering a question. 
+        2. Always use the 'report_grounding' tool to report the source of information from the knowledge base. 
+        3. Produce an answer that's as short as possible. If the answer isn't in the knowledge base, say you don't know.
+    """.strip()
+
     attach_rag_tools(rtmt,
         credentials=search_credential,
         search_endpoint=os.environ.get("AZURE_SEARCH_ENDPOINT"),


### PR DESCRIPTION
This pull request includes a modification to the system message in the `create_app` function within `app/backend/app.py`. The change improves the readability and maintainability of the code by converting a concatenated string into a multi-line string.

The main reason for this change is to make it easier to modify the system message. I noticed that people find it hard to modify the concatenated strings, while a multi-line string is very easy to modify.

Code readability improvement:

* [`app/backend/app.py`](diffhunk://#diff-5f1d71f916fd982ef5a7ab0b78e419d64d02a77c7422911db11911a74f3a8ee6L43-R52): Changed the `rtmt.system_message` from a concatenated string to a multi-line string for better readability and maintainability.