### PR TITLE
Make Semantic Ranker optional

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -52,7 +52,7 @@ async def create_app():
 
     attach_rag_tools(rtmt,
         credentials=search_credential,
-        search_endpoint=os.environ.get("AZURE_SEARCH_ENDPOINT") ,
+        search_endpoint=os.environ.get("AZURE_SEARCH_ENDPOINT"),
         search_index=os.environ.get("AZURE_SEARCH_INDEX"),
         semantic_configuration=os.environ.get("AZURE_SEARCH_SEMANTIC_CONFIGURATION") or None,
         identifier_field=os.environ.get("AZURE_SEARCH_IDENTIFIER_FIELD") or "chunk_id",

--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -52,16 +52,16 @@ async def create_app():
 
     attach_rag_tools(rtmt,
         credentials=search_credential,
-        search_endpoint=os.environ.get("AZURE_SEARCH_ENDPOINT"),
-        search_index=os.environ.get("AZURE_SEARCH_INDEX"),
-        semantic_configuration=os.environ.get("AZURE_SEARCH_SEMANTIC_CONFIGURATION") or "default",
+        search_endpoint=os.environ.get("AZURE_SEARCH_ENDPOINT") or None,
+        search_index=os.environ.get("AZURE_SEARCH_INDEX") or None,
+        semantic_configuration=os.environ.get("AZURE_SEARCH_SEMANTIC_CONFIGURATION") or None,
         identifier_field=os.environ.get("AZURE_SEARCH_IDENTIFIER_FIELD") or "chunk_id",
         content_field=os.environ.get("AZURE_SEARCH_CONTENT_FIELD") or "chunk",
         embedding_field=os.environ.get("AZURE_SEARCH_EMBEDDING_FIELD") or "text_vector",
         title_field=os.environ.get("AZURE_SEARCH_TITLE_FIELD") or "title",
         use_vector_query=(os.environ.get("AZURE_SEARCH_USE_VECTOR_QUERY") == "true") or True
         )
-
+    
     rtmt.attach_to_app(app, "/realtime")
 
     current_directory = Path(__file__).parent

--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -52,8 +52,8 @@ async def create_app():
 
     attach_rag_tools(rtmt,
         credentials=search_credential,
-        search_endpoint=os.environ.get("AZURE_SEARCH_ENDPOINT") or None,
-        search_index=os.environ.get("AZURE_SEARCH_INDEX") or None,
+        search_endpoint=os.environ.get("AZURE_SEARCH_ENDPOINT") ,
+        search_index=os.environ.get("AZURE_SEARCH_INDEX"),
         semantic_configuration=os.environ.get("AZURE_SEARCH_SEMANTIC_CONFIGURATION") or None,
         identifier_field=os.environ.get("AZURE_SEARCH_IDENTIFIER_FIELD") or "chunk_id",
         content_field=os.environ.get("AZURE_SEARCH_CONTENT_FIELD") or "chunk",
@@ -61,7 +61,7 @@ async def create_app():
         title_field=os.environ.get("AZURE_SEARCH_TITLE_FIELD") or "title",
         use_vector_query=(os.environ.get("AZURE_SEARCH_USE_VECTOR_QUERY") == "true") or True
         )
-    
+
     rtmt.attach_to_app(app, "/realtime")
 
     current_directory = Path(__file__).parent

--- a/app/backend/ragtools.py
+++ b/app/backend/ragtools.py
@@ -51,20 +51,20 @@ _grounding_tool_schema = {
 
 async def _search_tool(
     search_client: SearchClient, 
-    semantic_configuration: str,
+    semantic_configuration: str | None,
     identifier_field: str,
     content_field: str,
     embedding_field: str,
     use_vector_query: bool,
     args: Any) -> ToolResult:
     print(f"Searching for '{args['query']}' in the knowledge base.")
-    # Hybrid + Reranking query using Azure AI Search
+    # Hybrid query using Azure AI Search with (optional) Semantic Ranker
     vector_queries = []
     if use_vector_query:
         vector_queries.append(VectorizableTextQuery(text=args['query'], k_nearest_neighbors=50, fields=embedding_field))
     search_results = await search_client.search(
-        search_text=args['query'], 
-        query_type="semantic",
+        search_text=args["query"], 
+        query_type="semantic" if semantic_configuration else "simple",
         semantic_configuration_name=semantic_configuration,
         top=5,
         vector_queries=vector_queries,
@@ -103,7 +103,7 @@ async def _report_grounding_tool(search_client: SearchClient, identifier_field: 
 def attach_rag_tools(rtmt: RTMiddleTier,
     credentials: AzureKeyCredential | DefaultAzureCredential,
     search_endpoint: str, search_index: str,
-    semantic_configuration: str,
+    semantic_configuration: str | None,
     identifier_field: str,
     content_field: str,
     embedding_field: str,


### PR DESCRIPTION
Not all regions do have the Semantic ranker available at the moment. See [regional availability](https://learn.microsoft.com/en-us/azure/search/search-region-support). 

This pull request includes changes to improve the handling of optional semantic configurations in the Azure AI Search integration. The most important changes are focused on ensuring that the semantic configuration parameters can be set to `None` if not provided.

This would be a breaking change as semantic ranker will be disabled if `AZURE_SEARCH_SEMANTIC_CONFIGURATION` is not set now. This will not raise any errors though.


* [`app/backend/app.py`](diffhunk://#diff-5f1d71f916fd982ef5a7ab0b78e419d64d02a77c7422911db11911a74f3a8ee6L52-R54): Modified the `create_app` function to set the `search_endpoint`, `search_index`, and `semantic_configuration` parameters to `None` if they are not provided in the environment variables.
* [`app/backend/ragtools.py`](diffhunk://#diff-8252d3ca52991b77563fd67ca3ac7c42e1cdffbeb287b4470bc43d2d2d407f00L54-R67): Updated the `_search_tool` and `_report_grounding_tool` functions to accept `semantic_configuration` as an optional parameter (`str | None`). Additionally, adjusted the query type to use "simple" if the `semantic_configuration` is not provided. [[1]](diffhunk://#diff-8252d3ca52991b77563fd67ca3ac7c42e1cdffbeb287b4470bc43d2d2d407f00L54-R67) [[2]](diffhunk://#diff-8252d3ca52991b77563fd67ca3ac7c42e1cdffbeb287b4470bc43d2d2d407f00L106-R106)