### PR TITLE
Update rtmt.py - pop gives the error when there are two message in the queue

### DIFF
--- a/app/backend/rtmt.py
+++ b/app/backend/rtmt.py
@@ -146,9 +146,12 @@ class RTMiddleTier:
                         })
                     if "response" in message:
                         replace = False
-                        for i, output in enumerate(reversed(message["response"]["output"])):
+                        # Iterate in reverse while calculating the correct index
+                        for reverse_index, output in enumerate(reversed(message["response"]["output"])):
                             if output["type"] == "function_call":
-                                message["response"]["output"].pop(i)
+                                original_index = output_len - 1 - reverse_index  # Map reversed index to the original
+                                print("Len of message[response][output]:", output_len, ", output:", message["response"]["output"])
+                                message["response"]["output"].pop(original_index)
                                 replace = True
                         if replace:
                             updated_message = json.dumps(message)                        


### PR DESCRIPTION
Update rtmt.py - pop gives the error when there are two message in the queue and there will be index out of range
index out of the range. 

Consider two message are in the queue and poping both like
total size is 2
pop(1) - it will remove the first element and size becomes 1
pop(2) - it will try to remove the 2nd element but size is 1 and it will be index out of bounds