### PR TITLE
Fix two issues (1 frontend/ 1 backend)

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -59,7 +59,7 @@ async def create_app():
         content_field=os.environ.get("AZURE_SEARCH_CONTENT_FIELD") or "chunk",
         embedding_field=os.environ.get("AZURE_SEARCH_EMBEDDING_FIELD") or "text_vector",
         title_field=os.environ.get("AZURE_SEARCH_TITLE_FIELD") or "title",
-        use_vector_query=(os.environ.get("AZURE_SEARCH_USE_VECTOR_QUERY") == "true") or True
+        use_vector_query=(os.getenv("AZURE_SEARCH_USE_VECTOR_QUERY", "true") == "true")
         )
 
     rtmt.attach_to_app(app, "/realtime")

--- a/app/frontend/tailwind.config.js
+++ b/app/frontend/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+import plugin from "tailwindcss-animate";
+
 export default {
     darkMode: ["class"],
     content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
@@ -58,5 +60,5 @@ export default {
             }
         }
     },
-    plugins: [require("tailwindcss-animate")]
+    plugins: [plugin]
 };

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -93,7 +93,7 @@
       "value": "${AZURE_OPENAI_REALTIME_DEPLOYMENT_CAPACITY=1}"
     },
     "realtimeDeploymentVersion": {
-      "value": "${AZURE_OPENAI_REALTIME_DEPLOYMENT_VERSION=2024-10-01}"
+      "value": "${AZURE_OPENAI_REALTIME_DEPLOYMENT_VERSION=2024-12-17}"
     },
     "embeddingDeploymentCapacity": {
       "value": "${AZURE_OPENAI_EMB_DEPLOYMENT_CAPACITY=30}"


### PR DESCRIPTION


Environment variable handling:

* [`app/backend/app.py`](diffhunk://#diff-5f1d71f916fd982ef5a7ab0b78e419d64d02a77c7422911db11911a74f3a8ee6L62-R62): Modified the `use_vector_query` assignment to use `os.getenv` for better environment variable handling. It was resulting in True even if you set it to false, silly me.

Tailwind CSS plugin usage:

* [`app/frontend/tailwind.config.js`](diffhunk://#diff-b1f89347cdd34ab6bd1ea497e7b421488207d4937dbe9cceb38593d38c36290fR2-R3): Changed to use import instead of require. I was getting errors with "require is not defined".
