### PR TITLE
Fix: Use searchable field instead of identifier in Azure Search

### DIFF
--- a/app/backend/ragtools.py
+++ b/app/backend/ragtools.py
@@ -68,6 +68,7 @@ async def _search_tool(
         semantic_configuration_name=semantic_configuration,
         top=5,
         vector_queries=vector_queries,
+        search_fields=[content_field],
         select=", ".join([identifier_field, content_field])
     )
     result = ""
@@ -86,7 +87,7 @@ async def _report_grounding_tool(search_client: SearchClient, identifier_field: 
     # Use search instead of filter to align with how detailt integrated vectorization indexes
     # are generated, where chunk_id is searchable with a keyword tokenizer, not filterable 
     search_results = await search_client.search(search_text=list, 
-                                                search_fields=[identifier_field], 
+                                                search_fields=[content_field], 
                                                 select=[identifier_field, title_field, content_field], 
                                                 top=len(sources), 
                                                 query_type="full")


### PR DESCRIPTION
Resolved an issue where Azure Search was using the identifier field (typically id) as the search field. Since identifier fields are not marked as searchable in the index, this caused search requests to fail. The implementation now ensures that only valid searchable fields are used for query execution, preventing HttpResponseError related to non-searchable fields.