### PR TITLE
Restrict WebSocket connection to be active during recording

### DIFF
--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -39,7 +39,8 @@ function App() {
             });
 
             setGroundingFiles(prev => [...prev, ...files]);
-        }
+        },
+        shouldConnect: isRecording
     });
 
     const { reset: resetAudioPlayer, play: playAudio, stop: stopAudioPlayer } = useAudioPlayer();

--- a/app/frontend/src/hooks/useRealtime.tsx
+++ b/app/frontend/src/hooks/useRealtime.tsx
@@ -19,6 +19,7 @@ type Parameters = {
     aoaiModelOverride?: string;
 
     enableInputAudioTranscription?: boolean;
+    shouldConnect: boolean;
     onWebSocketOpen?: () => void;
     onWebSocketClose?: () => void;
     onWebSocketError?: (event: Event) => void;
@@ -39,6 +40,7 @@ export default function useRealTime({
     aoaiApiKeyOverride,
     aoaiModelOverride,
     enableInputAudioTranscription,
+    shouldConnect,
     onWebSocketOpen,
     onWebSocketClose,
     onWebSocketError,
@@ -55,13 +57,17 @@ export default function useRealTime({
         ? `${aoaiEndpointOverride}/openai/realtime?api-key=${aoaiApiKeyOverride}&deployment=${aoaiModelOverride}&api-version=2024-10-01-preview`
         : `/realtime`;
 
-    const { sendJsonMessage } = useWebSocket(wsEndpoint, {
-        onOpen: () => onWebSocketOpen?.(),
-        onClose: () => onWebSocketClose?.(),
-        onError: event => onWebSocketError?.(event),
-        onMessage: event => onMessageReceived(event),
-        shouldReconnect: () => true
-    });
+    const { sendJsonMessage } = useWebSocket(
+        wsEndpoint,
+        {
+            onOpen: () => onWebSocketOpen?.(),
+            onClose: () => onWebSocketClose?.(),
+            onError: event => onWebSocketError?.(event),
+            onMessage: event => onMessageReceived(event),
+            shouldReconnect: () => true
+        },
+        shouldConnect
+    );
 
     const startSession = () => {
         const command: SessionUpdateCommand = {


### PR DESCRIPTION
## Description

This change restricts WebSocket connections to only be active during recording sessions, improving resource management and connection efficiency by preventing unnecessary connections when not recording.

## Changes

  - WebSocket connections now start only when recording begins
  - Connections are properly closed when recording stops

## Testing

  - Confirmed connection created when starting recording
  - Confirmed no connection attempts when not recording
  - Not answers from the previous recordings are played (This happens in slow network)

